### PR TITLE
Check for location being `undefined`

### DIFF
--- a/MMM-GoogleCalendar.js
+++ b/MMM-GoogleCalendar.js
@@ -477,7 +477,7 @@ Module.register("MMM-GoogleCalendar", {
       }
 
       if (this.config.showLocation) {
-        if (event.location !== false) {
+        if (event.location && event.location !== false) {
           const locationRow = document.createElement("tr");
           locationRow.className = "normal xsmall light";
 

--- a/MMM-GoogleCalendar.js
+++ b/MMM-GoogleCalendar.js
@@ -477,7 +477,7 @@ Module.register("MMM-GoogleCalendar", {
       }
 
       if (this.config.showLocation) {
-        if (event.location && event.location !== false) {
+        if (event.location) {
           const locationRow = document.createElement("tr");
           locationRow.className = "normal xsmall light";
 


### PR DESCRIPTION
`event.location` is being set to `undefined` elsewhere, and `undefined !== false` evaluates to true, so the module is attempting to set the location in the UI even for events without locations.

Fixes #14 