### PR TITLE
Prevent duplicate events from displaying

### DIFF
--- a/MMM-GoogleCalendar.js
+++ b/MMM-GoogleCalendar.js
@@ -737,7 +737,7 @@ Module.register("MMM-GoogleCalendar", {
     for (const evt of eventList) {
       if (
         evt.summary === event.summary &&
-        parseInt(evt.start) === parseInt(event.start)
+        parseInt(evt.startDate) === parseInt(event.startDate)
       ) {
         return true;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mmm-googlecalendar",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mmm-googlecalendar",
-      "version": "2.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/local-auth": "^2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mmm-googlecalendar",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mmm-googlecalendar",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/local-auth": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmm-googlecalendar",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "displayName": "MMM-GoogleCalendar",
   "description": "Display your Google calendars in MagicMirror (including google's family calendar) without using iCals nor any public calendar. ",
   "main": "MMM-GoogleCalendar.js",


### PR DESCRIPTION
When multiple calendars are displayed, and events are shared between them, multiple versions of the event are displayed.
This change looks at the correct attribute to prevent displaying the event more than once. 