### PR TITLE
fix: support showEnd for dataheaders

### DIFF
--- a/MMM-GoogleCalendar.js
+++ b/MMM-GoogleCalendar.js
@@ -359,6 +359,12 @@ Module.register("MMM-GoogleCalendar", {
             this.timeClassForCalendar(event.calendarID);
           timeWrapper.style.paddingLeft = "2px";
           timeWrapper.innerHTML = moment(event.startDate).format("LT");
+
+          // Add endDate to dataheaders if showEnd is enabled
+          if (this.config.showEnd) {
+            timeWrapper.innerHTML += ` - ${this.capFirst(moment(event.endDate, "x").format("LT"))}`;
+          }
+          
           eventWrapper.appendChild(timeWrapper);
           titleWrapper.classList.add("align-right");
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mmm-googlecalendar",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mmm-googlecalendar",
-      "version": "2.0.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/local-auth": "^2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mmm-googlecalendar",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mmm-googlecalendar",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/local-auth": "^2.1.0",


### PR DESCRIPTION
Add support for `showEnd` configuration property in case of `dateheaders` time format selected