### PR TITLE
Retrying fetch the calendar after an error

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -223,14 +223,14 @@ module.exports = NodeHelper.create({
             id: identifier,
             error_type
           });
-          return;
+        } else {
+          const events = res.data.items;
+          Log.info(
+            `${this.name}: ${events.length} events loaded for ${calendarID}`
+          );
+          this.broadcastEvents(events, identifier, calendarID); 
         }
-
-        const events = res.data.items;
-        Log.info(
-          `${this.name}: ${events.length} events loaded for ${calendarID}`
-        );
-        this.broadcastEvents(events, identifier, calendarID);
+        
         this.scheduleNextCalendarFetch(
           calendarID,
           fetchInterval,


### PR DESCRIPTION
There would be a more elegant solution, like checking the err.retry property, but anyway this will fix the calendar stop being updated after an error occurred, like an ECONNRESET