### PR TITLE
Add properties for being compatible with default calendar module broadcasting

### DIFF
--- a/MMM-GoogleCalendar.js
+++ b/MMM-GoogleCalendar.js
@@ -1045,13 +1045,10 @@ Module.register("MMM-GoogleCalendar", {
         // Make a broadcasting event to be compatible with the default calendar module.
         event.title = event.summary;
         event.fullDayEvent = (event.start?.date && event.end?.date) ? true : false;
-        if (event.fullDayEvent) {
-          event.startDate = moment(event.start?.date).valueOf();
-          event.endDate = moment(event.end?.date).valueOf();
-        } else {
-          event.startDate = moment(event.start?.dateTime).valueOf();
-          event.endDate = moment(event.end?.dateTime).valueOf();
-        }
+        let startDate = event.start?.date ?? event.start?.dateTime;
+        let endDate = event.end?.date ?? event.end?.dateTime;
+        event.startDate = (startDate) ? moment(startDate).valueOf() : null;
+        event.endDate = (endDate) ? moment(endDate).valueOf() : null;
         eventList.push(event);
       }
     }

--- a/MMM-GoogleCalendar.js
+++ b/MMM-GoogleCalendar.js
@@ -1041,6 +1041,17 @@ Module.register("MMM-GoogleCalendar", {
         event.calendarName = this.calendarNameForCalendar(calendarID);
         event.color = this.colorForCalendar(calendarID);
         delete event.calendarID;
+
+        // Make a broadcasting event to be compatible with the default calendar module.
+        event.title = event.summary;
+        event.fullDayEvent = (event.start?.date && event.end?.date) ? true : false;
+        if (event.fullDayEvent) {
+          event.startDate = moment(event.start?.date).valueOf();
+          event.endDate = moment(event.end?.date).valueOf();
+        } else {
+          event.startDate = moment(event.start?.dateTime).valueOf();
+          event.endDate = moment(event.end?.dateTime).valueOf();
+        }
         eventList.push(event);
       }
     }


### PR DESCRIPTION
The notifications of this module lack some fields of event, so it is not fully compatible with that of the default calendar module. Therefore, in other 3rd party modules (e.g. MMM-CalendarExt3 suites), there would be some issues.

This PR adds `startDate`, `endDate`, `title` and `fullDayEvent` to the event which will be broadcasted.