### PR TITLE
Fix symbol class handling for rendering and broadcasting

### DIFF
--- a/MMM-GoogleCalendar.js
+++ b/MMM-GoogleCalendar.js
@@ -278,7 +278,7 @@ Module.register("MMM-GoogleCalendar", {
         }
         symbols.forEach((s, index) => {
           const symbol = document.createElement("span");
-          symbol.className = "fa fa-fw fa-" + s;
+          symbol.className = this.symbolClassForCalendar(event.calendarID) + s;
           if (index > 0) {
             symbol.style.paddingLeft = "5px";
           }
@@ -1069,8 +1069,8 @@ Module.register("MMM-GoogleCalendar", {
     const eventList = [];
     for (const calendarID in this.calendarData) {
       for (const ev of this.calendarData[calendarID]) {
-        const event = Object.assign({}, ev);
-        event.symbol = this.symbolsForEvent(event);
+        const event = Object.assign({calendarID:calendarID}, ev);
+        event.symbol = (this.symbolsForEvent(event) || []).map(s => this.symbolClassForCalendar(calendarID) + s);
         event.calendarName = this.calendarNameForCalendar(calendarID);
         event.color = this.colorForCalendar(calendarID);
         delete event.calendarID;


### PR DESCRIPTION
I was trying to setup a dashboard with MMM-CalendarExt3 and MMM-CalendarExt3Journal. When doing so I could not make the symbols to work. Upon diving deep I have realized that there are some peculiarities about how symbol classes and symbols are being handled.

1. `calendarID` was not stored on the event in the eventList. This led to always showing the default icon for the module (`'calendar'`). I have updated line 1072 to explicitly set `calendarID` on the cloned event. This should be safe as it is removed in line 1076 either way.
2. updated rendering and broadcasting to include configured `symbolClass` to mimic the native's calendar format.