### PR TITLE
fix: honor maximumNumberOfDays by sending timeMax to events.list

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -42,6 +42,7 @@ module.exports = NodeHelper.create({
         payload.fetchInterval,
         payload.maximumEntries,
         payload.pastDaysCount,
+        payload.maximumNumberOfDays,
         payload.id
       );
     }
@@ -269,6 +270,7 @@ module.exports = NodeHelper.create({
    * @param {number} fetchInterval How often does the calendar needs to be fetched in ms
    * @param {number} maximumEntries The maximum number of events fetched.
    * @param {number} pastDaysCount Number of past days to fetch events from.
+   * @param {number} maximumNumberOfDays Number of future days to fetch events into.
    * @param {string} identifier ID of the module
    */
   fetchCalendar: function (
@@ -276,6 +278,7 @@ module.exports = NodeHelper.create({
     fetchInterval,
     maximumEntries,
     pastDaysCount,
+    maximumNumberOfDays = 365,
     identifier
   ) {
     this.calendarService.events.list(
@@ -283,6 +286,9 @@ module.exports = NodeHelper.create({
         calendarId: calendarID,
         timeMin: new Date(
           new Date().setDate(new Date().getDate() - pastDaysCount)
+        ).toISOString(),
+        timeMax: new Date(
+          new Date().setDate(new Date().getDate() + maximumNumberOfDays)
         ).toISOString(),
         maxResults: maximumEntries,
         singleEvents: true,
@@ -320,6 +326,7 @@ module.exports = NodeHelper.create({
           fetchInterval,
           maximumEntries,
           pastDaysCount,
+          maximumNumberOfDays,
           identifier
         );
       }
@@ -331,6 +338,7 @@ module.exports = NodeHelper.create({
     fetchInterval,
     maximumEntries,
     pastDaysCount,
+    maximumNumberOfDays,
     identifier
   ) {
     if (this.isHelperActive) {
@@ -342,6 +350,7 @@ module.exports = NodeHelper.create({
           fetchInterval,
           maximumEntries,
           pastDaysCount,
+          maximumNumberOfDays,
           identifier
         );
       }, fetchInterval);


### PR DESCRIPTION
The Google Calendar API call in fetchCalendar sets only `timeMin` and `maxResults`. Combined with `singleEvents: true`, recurring events are expanded into individual instances, which quickly consume the result set. On busy calendars this clips one-off events past ~2 weeks even when `maximumNumberOfDays` is set higher (e.g. 60), because the API has no horizon and returns all future events sorted by startTime up to `maxResults` (hard cap 2500). The configured `maximumNumberOfDays` was acting as a client-side display filter only.

Thread `payload.maximumNumberOfDays` from the ADD_CALENDAR socket notification through `fetchCalendar` and `scheduleNextCalendarFetch`, and send it as `timeMax` to `events.list`. The API now returns only events in the configured window, `maxResults` becomes effectively unreachable for normal use, and `maximumNumberOfDays` takes effect at the source instead of only at render time.

No config or API surface change — `maximumNumberOfDays` is already a documented option (see MMM-GoogleCalendar.js defaults).