### PR TITLE
Fix: calendar symbol not applied when broadcasting events (#89)

### DIFF
--- a/MMM-GoogleCalendar.js
+++ b/MMM-GoogleCalendar.js
@@ -1076,6 +1076,7 @@ Module.register("MMM-GoogleCalendar", {
     for (const calendarID in this.calendarData) { // `calendarID` is a key, `const` is appropriate
       for (const ev of this.calendarData[calendarID]) { // Use for...of for arrays
         const event = { ...ev }; // Use spread syntax for shallow clone instead of Object.assign
+        event.calendarID = calendarID;
         event.symbol = this.symbolsForEvent(event);
         event.calendarName = this.calendarNameForCalendar(calendarID);
         event.color = this.colorForCalendar(calendarID);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmm-googlecalendar",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "displayName": "MMM-GoogleCalendar",
   "description": "Display your Google calendars in MagicMirror (including google's family calendar) without using iCals nor any public calendar. ",
   "main": "MMM-GoogleCalendar.js",


### PR DESCRIPTION
## Summary

- `broadcastEvents()` was calling `symbolsForEvent(event)` before `event.calendarID` was set, causing the lookup to fail and fall back to the default `"calendar"` symbol
- Fix: assign `event.calendarID = calendarID` before the `symbolsForEvent` call
- Bumps version to 1.2.1

Closes #89

## Test plan
- [ ] Configure a calendar with a custom `symbol` and `broadcastEvents: true`
- [ ] Verify the broadcast `CALENDAR_EVENTS` notification carries the correct per-calendar symbol instead of the default `"calendar"` symbol