### PR TITLE
Fix: apply PRIVATE_EVENT fallback in broadcastEvents

### DIFF
--- a/MMM-GoogleCalendar.js
+++ b/MMM-GoogleCalendar.js
@@ -1083,7 +1083,7 @@ Module.register("MMM-GoogleCalendar", {
         delete event.calendarID;
 
         // Make a broadcasting event to be compatible with the default calendar module.
-        event.title = event.summary;
+        event.title = event.summary === undefined ? this.translate("PRIVATE_EVENT") : event.summary;
 
         event.fullDayEvent = !!(event.start?.date && event.end?.date);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmm-googlecalendar",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "displayName": "MMM-GoogleCalendar",
   "description": "Display your Google calendars in MagicMirror (including google's family calendar) without using iCals nor any public calendar. ",
   "main": "MMM-GoogleCalendar.js",


### PR DESCRIPTION
## Summary

- #88 fixed `event.title = event.summary` in `createEventList` to handle private events, but `broadcastEvents` had the same unguarded assignment at line 1086
- Private events broadcast via `CALENDAR_EVENTS` would have `undefined` as their title
- Applies the same guard: `event.summary === undefined ? this.translate("PRIVATE_EVENT") : event.summary`
- Bumps version to 1.2.2

## Test plan
- [ ] Create or have a private Google Calendar event
- [ ] Enable `broadcastEvents: true`
- [ ] Verify the broadcast `CALENDAR_EVENTS` notification carries `"Private Event"` as the title instead of `undefined`