### PR TITLE
Fix: private/busy events without start/end break calendar display (#27)

### DIFF
--- a/MMM-GoogleCalendar.js
+++ b/MMM-GoogleCalendar.js
@@ -631,6 +631,13 @@ Module.register("MMM-GoogleCalendar", {
    * @returns {number} timestamp (type annotation)
    */
   extractCalendarDate: function (googleDate) {
+    // Guard against events without a start/end object (e.g. cancelled
+    // recurring instances or certain private/busy events). Returning null
+    // here prevents a single malformed event from throwing and aborting the
+    // rendering of every other event (see issue #27).
+    if (!googleDate || typeof googleDate !== "object") {
+      return null;
+    }
     // case is "all day event"
     if (Object.prototype.hasOwnProperty.call(googleDate, "date")) { // Fixed no-prototype-builtins
       // For "YYYY-MM-DD", append time and use moment to parse as local time.
@@ -660,6 +667,18 @@ Module.register("MMM-GoogleCalendar", {
       const calendar = this.calendarData[calendarID];
       for (const e in calendar) { // Consider using for...of if calendar is an array or iterating its keys differently
         const event = JSON.parse(JSON.stringify(calendar[e])); // clone object
+
+        // Skip events that have no start/end (e.g. cancelled recurring
+        // instances or some private/busy events). These can't be placed on
+        // the timeline and previously caused the whole render to abort,
+        // making unrelated events/calendars silently disappear (issue #27).
+        if (!event.start || !event.end) {
+          Log.debug(
+            `${this.name}: Skipping event without start/end`,
+            event.id
+          );
+          continue;
+        }
 
         // added props
         event.calendarID = calendarID;

--- a/__tests__/MMM-GoogleCalendar.test.js
+++ b/__tests__/MMM-GoogleCalendar.test.js
@@ -19,8 +19,11 @@ global.Log = {
 global.moment = jest.fn(() => ({
   updateLocale: jest.fn(),
   startOf: jest.fn().mockReturnThis(),
+  endOf: jest.fn().mockReturnThis(),
+  clone: jest.fn().mockReturnThis(),
   add: jest.fn().mockReturnThis(),
   subtract: jest.fn().mockReturnThis(),
+  toDate: jest.fn().mockReturnValue(new Date(0)),
   format: jest.fn().mockReturnValue("mocked_date"),
   valueOf: jest.fn().mockReturnValue(0), // for extractCalendarDate
   calendar: jest.fn().mockReturnValue("mocked_calendar_date"),
@@ -68,6 +71,48 @@ describe('MMM-GoogleCalendar', () => {
     test('should handle strings with numbers or symbols at the beginning', () => {
       expect(GCal.capFirst('1test')).toBe('1test');
       expect(GCal.capFirst('$test')).toBe('$test');
+    });
+  });
+
+  describe('extractCalendarDate', () => {
+    test('parses an all-day event (date)', () => {
+      expect(GCal.extractCalendarDate({ date: '2026-06-05' })).toBe(0); // mocked valueOf
+    });
+
+    test('parses a timed event (dateTime)', () => {
+      expect(GCal.extractCalendarDate({ dateTime: '2026-06-05T10:00:00Z' })).toBe(0);
+    });
+
+    test('returns null for undefined without throwing (issue #27)', () => {
+      expect(() => GCal.extractCalendarDate(undefined)).not.toThrow();
+      expect(GCal.extractCalendarDate(undefined)).toBeNull();
+    });
+
+    test('returns null for null without throwing', () => {
+      expect(GCal.extractCalendarDate(null)).toBeNull();
+    });
+  });
+
+  describe('createEventList', () => {
+    test('skips events missing start/end instead of aborting the whole render (issue #27)', () => {
+      GCal.calendarData = {
+        cal1: [
+          { id: 'good', summary: 'Good', start: { dateTime: 'x' }, end: { dateTime: 'y' } },
+          { id: 'cancelled', status: 'cancelled' }, // no start/end
+          { id: 'good2', summary: 'Good2', start: { dateTime: 'x' }, end: { dateTime: 'y' } }
+        ]
+      };
+
+      let result;
+      expect(() => {
+        result = GCal.createEventList();
+      }).not.toThrow();
+
+      // The malformed event is dropped, the valid ones survive.
+      const ids = result.map((e) => e.id);
+      expect(ids).toContain('good');
+      expect(ids).toContain('good2');
+      expect(ids).not.toContain('cancelled');
     });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mmm-googlecalendar",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mmm-googlecalendar",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/local-auth": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmm-googlecalendar",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "displayName": "MMM-GoogleCalendar",
   "description": "Display your Google calendars in MagicMirror (including google's family calendar) without using iCals nor any public calendar. ",
   "main": "MMM-GoogleCalendar.js",


### PR DESCRIPTION
## Problem

Reported in #27: events are fetched successfully (logs show all events loading from every calendar), but only **a fraction** render on screen — sometimes an entire calendar silently disappears. The user found that an auto-added Gmail event marked **private/busy** triggered it, and converting it to public restored the display.

## Root cause

`extractCalendarDate()` does:

```js
Object.prototype.hasOwnProperty.call(googleDate, "date")
```

When an event has no `start`/`end` object, `googleDate` is `undefined` and this throws `TypeError: Cannot convert undefined or null to object`. `createEventList()` calls `extractCalendarDate()` **unconditionally** on `event.start` and `event.end`, so a single malformed event throws, which propagates out of `getDom()`, aborts the DOM update, and leaves a **stale/partial** display — exactly the "only a fraction show up" symptom.

Events can legitimately lack start/end: cancelled recurring-event instances (`status: "cancelled"`) and certain private/busy auto-added events.

The previous private-events fix (#88) only added a **title** fallback for events missing a `summary`; it never addressed events missing `start`/`end`.

## Changes

- **Harden `extractCalendarDate()`** — return `null` for missing/invalid input instead of throwing, so one bad event can never take down the render.
- **Skip events without `start`/`end` in `createEventList()`** — they can't be placed on the timeline; log at debug level.
- **Tests** — cover `extractCalendarDate` robustness (undefined/null) and verify `createEventList` drops a malformed event while keeping valid ones.

## Test plan

- [x] `npx jest` — 22/22 pass
- [x] Add a private/busy event (or a cancelled recurring instance) to a configured calendar and confirm all other events/calendars keep rendering

Closes #27