### PR TITLE
ci: automate version bumping on merge to main

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,55 @@
+name: Auto version bump
+
+# Bumps the package version once, on main, after a PR is merged.
+# Doing it here (instead of in each feature branch) avoids version
+# collisions between PRs developed in parallel.
+#
+# Default bump is "patch". To bump minor or major, add a label named
+# "minor" or "major" to the PR before merging.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    # Only run for real merges, and never react to the bot's own bump commit.
+    if: >
+      github.event.pull_request.merged == true &&
+      !startsWith(github.event.pull_request.title, 'chore: bump version')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Determine bump level from PR labels
+        id: level
+        run: |
+          if   ${{ contains(github.event.pull_request.labels.*.name, 'major') }}; then
+            echo "level=major" >> "$GITHUB_OUTPUT"
+          elif ${{ contains(github.event.pull_request.labels.*.name, 'minor') }}; then
+            echo "level=minor" >> "$GITHUB_OUTPUT"
+          else
+            echo "level=patch" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump version, commit and tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # npm version updates package.json + package-lock.json, commits, and tags.
+          # [skip ci] keeps the resulting push from re-triggering workflows.
+          npm version ${{ steps.level.outputs.level }} \
+            -m "chore: bump version to %s [skip ci]"
+          git push origin main --follow-tags


### PR DESCRIPTION
## What

Adds a GitHub Action that bumps the package version automatically, **once, on `main`, after a PR is merged** — so we stop bumping by hand in every feature PR.

## Why

Manual per-PR bumping has two problems:
1. It's a step that's easy to forget.
2. **Version collisions** — PRs developed in parallel both grab the same next version (e.g. #94 and #95 both wanted `1.2.3`), because neither branch knows about the other.

Bumping at merge time, on `main`, removes the manual step and makes collisions impossible (bumps are serialized on `main`).

## How it works

- Trigger: a PR is **merged** into `main`.
- Default bump is **patch**. For a bigger jump, add a **`minor`** or **`major`** label to the PR before merging.
- `npm version` updates `package.json` + `package-lock.json`, commits (`chore: bump version to X [skip ci]`), and creates a git tag. `[skip ci]` prevents a re-trigger loop, and a title guard skips the bot's own bump commit.

**Contributor impact: none.** No commit-message conventions required (unlike release-please / semantic-release). Just write code; the version takes care of itself.

## ⚠️ Before this works

- **Branch protection on `main`:** if direct pushes are restricted, either allow `github-actions[bot]` to bypass, or switch the push to use a PAT. Without that the action will fail to push.
- **Stop hand-bumping:** once this lands, feature PRs should *not* touch the version. (PR #95 still has a manual `1.2.4` bump from before this existed — fine to keep for that one.)

## Test plan

- [ ] Merge a trivial PR and confirm the action pushes a `chore: bump version to 1.2.x` commit + tag to `main`, and does not loop.
- [ ] Merge a PR labeled `minor` and confirm a minor bump.