### PR TITLE
Feat: date-only relative label for all-day events (#85)

### DIFF
--- a/MMM-GoogleCalendar.js
+++ b/MMM-GoogleCalendar.js
@@ -431,7 +431,15 @@ Module.register("MMM-GoogleCalendar", {
           }
         } else {
           // Show relative times
-          if (event.startDate >= now) {
+          if (event.fullDayEvent) {
+            // All-day events (e.g. holidays) have no meaningful time of day,
+            // so "at 12:00 AM", "in 5 hours" or "Running" is misleading.
+            // Show a date-only label instead: Today / Tomorrow / weekday /
+            // date. (issue #85)
+            timeWrapper.innerHTML = this.fullDayEventRelativeLabel(
+              event.startDate
+            );
+          } else if (event.startDate >= now) {
             // Use relative  time
             if (!this.config.hideTime) {
               timeWrapper.innerHTML = this.capFirst(
@@ -1093,6 +1101,30 @@ Module.register("MMM-GoogleCalendar", {
    */
   capFirst: function (string) {
     return string.charAt(0).toUpperCase() + string.slice(1);
+  },
+
+  /**
+   * Builds a date-only relative label for an all-day event (no time of day):
+   * Today / Tomorrow / weekday / configured date format. Used so holidays and
+   * other all-day events don't show misleading times such as "in 5 hours" or
+   * "Running" (issue #85).
+   *
+   * Relies only on existing infrastructure: TODAY/TOMORROW are MagicMirror
+   * core translation keys, and moment is locale-aware, so this works in every
+   * supported language without adding translation strings.
+   *
+   * @param {number} startDate The event start timestamp.
+   * @returns {string} The capitalized relative label.
+   */
+  fullDayEventRelativeLabel: function (startDate) {
+    return this.capFirst(
+      moment(startDate).calendar(null, {
+        sameDay: `[${this.translate("TODAY")}]`,
+        nextDay: `[${this.translate("TOMORROW")}]`,
+        nextWeek: "dddd",
+        sameElse: this.config.dateFormat
+      })
+    );
   },
 
   /**

--- a/__tests__/MMM-GoogleCalendar.test.js
+++ b/__tests__/MMM-GoogleCalendar.test.js
@@ -156,5 +156,22 @@ describe('MMM-GoogleCalendar', () => {
     });
   });
 
+  describe('fullDayEventRelativeLabel', () => {
+    test('builds a date-only label from core TODAY/TOMORROW keys, no time (issue #85)', () => {
+      GCal.translate = jest.fn((key) => key);
+      GCal.config.dateFormat = 'MMM Do';
+
+      const label = GCal.fullDayEventRelativeLabel(0);
+
+      // Returns a non-empty capitalized string (moment is mocked).
+      expect(typeof label).toBe('string');
+      expect(label.length).toBeGreaterThan(0);
+
+      // Uses date-only relative keys (no "at LT" time component).
+      expect(GCal.translate).toHaveBeenCalledWith('TODAY');
+      expect(GCal.translate).toHaveBeenCalledWith('TOMORROW');
+    });
+  });
+
   // Add more describe blocks for other pure functions if identified
 });


### PR DESCRIPTION
## Request

From #85: a calendar of only holidays (all-day events) shows misleading time info in the right column. The user wants all-day events to read like "Today"/"Tomorrow"/weekday instead.

## Why it happened

In the default `timeFormat: "relative"`, all-day events fell through the timed-event logic:
- **Today's** all-day event: `startDate` is today's midnight, which is `< now`, so it hit the "ongoing" branch → **"Running"**.
- An all-day event a few hours out: `startDate - now < getRelative` hours → **"in 5 hours"**.
- Otherwise: `moment().calendar()` → **"Today at 12:00 AM"**.

None of these make sense for something with no time of day.

## Change

All-day events now render a **date-only** label — Today / Tomorrow / weekday / configured `dateFormat` — via a new `fullDayEventRelativeLabel()` helper. Timed events are untouched. Other modes (`dateheaders` already omits the time; `absolute` already has `nextDaysRelative`) are unchanged.

## Localization — no new strings needed

This was the main concern on the issue. It rides entirely on existing infrastructure:
- **`TODAY` / `TOMORROW` are MagicMirror *core* translation keys** (already used elsewhere in this module), shipped in every supported language.
- **Weekday names / date formats come from moment**, which is already locale-aware (`moment.updateLocale(config.language, ...)` in `start()`).

So it works in all languages without touching `translations/`.

## Test plan

- [x] `npx jest` — 30/30 pass (1 new test for the helper)
- [x] Visual: a holiday calendar shows "Today"/"Tomorrow"/weekday instead of "Running"/"in 5 hours"/"at 12:00 AM"

Note: version intentionally not bumped — the auto-bump workflow handles it on merge.

Closes #85