### PR TITLE
Fix: use Node's built-in fetch to avoid Electron/Node 24.17.0 'Premature close' (#99)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,7 @@ const baseConfig = {
     browser: true, // For MMM-GoogleCalendar.js
     node: true,    // For node_helper.js
     es6: true,
+    es2020: true,  // globalThis (used for the native-fetch workaround in node_helper.js)
     jest: true     // Added for Jest testing environment
   },
   parserOptions: {

--- a/node_helper.js
+++ b/node_helper.js
@@ -8,6 +8,33 @@ const Log = require("logger");
 const TOKEN_FILE_NAME = "token.json";
 const CREDENTIALS_FILE_NAME = "credentials.json";
 
+// gaxios (google-auth-library's HTTP transport) only uses the platform's built-in
+// fetch when a browser `window` global exists; with no `window` - i.e. node_helper.js
+// running inside MagicMirror's Electron main process (the default `npm start` path) -
+// it falls back to the node-fetch@2 npm package. On Node 24.17.0 that path throws a
+// false-positive "Premature close" (ERR_STREAM_PREMATURE_CLOSE) from an http.Agent
+// keep-alive regression (nodejs/node#63989, fixed upstream in a later 24.x), which
+// breaks OAuth token refresh and calendar fetches. Node's built-in fetch (undici) has
+// its own connection pool and never touches http.Agent, so pointing gaxios at it via
+// its documented `fetchImplementation` option (https://github.com/googleapis/gaxios#request-options)
+// sidesteps the bug while keeping the whole googleapis stack intact. gaxios' own JSDoc
+// for the option confirms the default: "will use the browser context if available, and
+// fall back to `node-fetch` in node.js otherwise." Both the token refresh and the events.list call go through
+// the OAuth2 client's transporter, so setting it there covers both. Harmless on
+// server-only mode and on unaffected Node versions. See issue #99.
+const nativeFetch =
+  typeof globalThis.fetch === "function"
+    ? (...args) => globalThis.fetch(...args)
+    : undefined;
+
+function useNativeFetch(oAuth2Client) {
+  if (nativeFetch && oAuth2Client && oAuth2Client.transporter) {
+    oAuth2Client.transporter.defaults = oAuth2Client.transporter.defaults || {};
+    oAuth2Client.transporter.defaults.fetchImplementation = nativeFetch;
+  }
+  return oAuth2Client;
+}
+
 module.exports = NodeHelper.create({
   // Override start method.
   start: function () {
@@ -122,6 +149,7 @@ module.exports = NodeHelper.create({
       client_secret,
       redirect_uris ? redirect_uris[0] : "http://localhost:8080" // Default redirect URI
     );
+    useNativeFetch(_this.oAuth2Client);
 
     _this.oAuth2Client.getToken(code, (err, token) => {
       if (err) {
@@ -224,6 +252,7 @@ module.exports = NodeHelper.create({
         client_secret,
         redirect_uris ? redirect_uris[0] : "http://localhost:8080" // Default redirect URI
       );
+      useNativeFetch(_this.oAuth2Client);
 
       // Check if we have previously stored a token.
       fs.readFile(path.join(_this.path, TOKEN_FILE_NAME), (err, token) => {


### PR DESCRIPTION
## Summary

Fixes the `Premature close` failure reported in #99, which breaks OAuth token refresh and calendar fetches on current Electron builds.

The root cause (thoroughly diagnosed by @daotsc in #99) is an **upstream Node.js 24.17.0 regression** ([nodejs/node#63989](https://github.com/nodejs/node/issues/63989)), already fixed in a later 24.x. `gaxios` (google-auth-library's HTTP transport) falls back to the `node-fetch@2` package when there's no browser `window` global — i.e. `node_helper.js` running inside MagicMirror's Electron main process — and that combination trips a false-positive `ERR_STREAM_PREMATURE_CLOSE` on Node 24.17.0's keep-alive path.

## Fix

Point `gaxios` at Node's built-in `fetch` (undici) via its documented [`fetchImplementation`](https://github.com/googleapis/gaxios#request-options) option. undici has its own connection pool and never touches `http.Agent`, so it sidesteps the regression. Both the token refresh and the `events.list` call go through the OAuth2 client's transporter, so a single injection point covers both.

## Why this approach (vs #100)

#100 fixes the same issue by replacing `googleapis` with hand-rolled `https` calls. This PR is a smaller alternative that:

- **keeps the entire `googleapis` stack** (auto token-refresh persistence, error typing, future API compatibility) instead of reimplementing it;
- **requires no re-authentication** — it doesn't change the `token.json` format, so existing users keep working after updating;
- is ~28 lines and adds no dependencies.

## Testing

- `npm test` — 30/30 passing
- `npx eslint node_helper.js` — clean
- Verified at runtime that the native fetch is attached to the transporter used for both the token refresh and the `events.list` dispatch.

⚠️ Needs confirmation on a machine that reproduces the bug (Electron 42.5.2 / Node 24.17.0). Asked the original reporter to verify.
